### PR TITLE
Allow subclasses to override page indicator listener

### DIFF
--- a/parallaxpager/src/main/java/com/prolificinteractive/parallaxpager/ParallaxContainer.java
+++ b/parallaxpager/src/main/java/com/prolificinteractive/parallaxpager/ParallaxContainer.java
@@ -21,6 +21,7 @@ public class ParallaxContainer extends FrameLayout implements ViewPager.OnPageCh
   private int containerWidth;
   private boolean isLooping = false;
   private final ParallaxPagerAdapter adapter;
+  private ViewPager.OnPageChangeListener pageChangeListener;
 
   public ParallaxContainer(Context context) {
     super(context);
@@ -87,10 +88,23 @@ public class ParallaxContainer extends FrameLayout implements ViewPager.OnPageCh
     // make view pager with same attributes as container
     viewPager = new ViewPager(getContext());
     viewPager.setLayoutParams(new LayoutParams(MATCH_PARENT, MATCH_PARENT));
-    viewPager.setOnPageChangeListener(this);
     viewPager.setId(R.id.parallax_pager);
     viewPager.setAdapter(adapter);
+    attachOnPageChangeListener(viewPager, this);
+
     addView(viewPager, 0);
+  }
+
+  /**
+   * Sets the {@link ViewPager.OnPageChangeListener} to the embedded {@link ViewPager}
+   * created by the container.
+   *
+   * This method can be overridden to add an page indicator to the parallax view. If
+   * this method is overriden, make sure that the listener methods are called on this
+   * class as well.
+   */
+  protected void attachOnPageChangeListener(ViewPager viewPager, ViewPager.OnPageChangeListener listener) {
+    viewPager.setOnPageChangeListener(listener);
   }
 
   // attach attributes in tag


### PR DESCRIPTION
There's no way to add a page indicator at the moment (for example, [ViewPagerIndicator](http://viewpagerindicator.com/)). The `ViewPager` is created internally to the `ParallaxContainer`, so there's no way to connect it to a `ViewPagerIndicator`. This pull request adds a protected method that lets you create a subclass which lets you add a page indicator. The method signature is:

```
protected void attachOnPageChangeListener(ViewPager viewPager, ViewPager.OnPageChangeListener listener)
```

I've created a subclass for my project that looks like this:

```
package com.example;

import android.content.Context;
import android.support.v4.view.ViewPager;
import android.util.AttributeSet;

import com.prolificinteractive.parallaxpager.ParallaxContainer;
import com.viewpagerindicator.PageIndicator;

public class PageIndicatorParallaxContainer extends ParallaxContainer {
    private PageIndicator mPageIndicator;

    @SuppressWarnings("UnusedDeclaration")
    public PageIndicatorParallaxContainer(Context context) {
        super(context);
    }

    @SuppressWarnings("UnusedDeclaration")
    public PageIndicatorParallaxContainer(Context context, AttributeSet attrs) {
        super(context, attrs);
    }

    @SuppressWarnings("UnusedDeclaration")
    public PageIndicatorParallaxContainer(Context context, AttributeSet attrs, int defStyle) {
        super(context, attrs, defStyle);
    }

    @Override
    protected void attachOnPageChangeListener(ViewPager viewPager,
                                              ViewPager.OnPageChangeListener listener) {
        if (mPageIndicator != null) {
            mPageIndicator.setOnPageChangeListener(listener);
            mPageIndicator.setViewPager(viewPager);

        } else {
            viewPager.setOnPageChangeListener(listener);
        }
    }

    public void setPageIndicator(PageIndicator pageIndicator) {
        this.mPageIndicator = pageIndicator;
    }
}
```

I don't think this class belongs in the ParallaxPager package, but it's a good example.
